### PR TITLE
Make distinction between provider and wallet

### DIFF
--- a/src/MarketSide.js
+++ b/src/MarketSide.js
@@ -35,12 +35,12 @@ function makeStakerContract(p) {
 }
 
 function syntheticTokenAddress(p, marketIndex, isLong) {
-  return makeLongShortContract(p).syntheticTokens(marketIndex, isLong);
+  return makeLongShortContract(Ethers$FloatJsClient.wrapProvider(p)).syntheticTokens(marketIndex, isLong);
 }
 
 function syntheticTokenTotalSupply(p, marketIndex, isLong) {
   return syntheticTokenAddress(p, marketIndex, isLong).then(function (address) {
-                return Promise.resolve(Contracts$FloatJsClient.Synth.make(address, p));
+                return Promise.resolve(Contracts$FloatJsClient.Synth.make(address, Ethers$FloatJsClient.wrapProvider(p)));
               }).then(function (synth) {
               return synth.totalSupply();
             });
@@ -48,7 +48,7 @@ function syntheticTokenTotalSupply(p, marketIndex, isLong) {
 
 function syntheticTokenBalance(p, marketIndex, isLong, owner) {
   return syntheticTokenAddress(p, marketIndex, isLong).then(function (address) {
-                return Promise.resolve(Contracts$FloatJsClient.Synth.make(address, p));
+                return Promise.resolve(Contracts$FloatJsClient.Synth.make(address, Ethers$FloatJsClient.wrapProvider(p)));
               }).then(function (synth) {
               return synth.balanceOf(owner);
             });
@@ -56,16 +56,16 @@ function syntheticTokenBalance(p, marketIndex, isLong, owner) {
 
 function stakedSyntheticTokenBalance(p, marketIndex, isLong, owner) {
   return syntheticTokenAddress(p, marketIndex, isLong).then(function (token) {
-              return makeStakerContract(p).userAmountStaked(token, owner);
+              return makeStakerContract(Ethers$FloatJsClient.wrapProvider(p)).userAmountStaked(token, owner);
             });
 }
 
 function marketSideValues(p, marketIndex) {
-  return makeLongShortContract(p).marketSideValueInPaymentToken(marketIndex);
+  return makeLongShortContract(Ethers$FloatJsClient.wrapProvider(p)).marketSideValueInPaymentToken(marketIndex);
 }
 
 function marketSideValue(p, marketIndex, isLong) {
-  return makeLongShortContract(p).marketSideValueInPaymentToken(marketIndex).then(function (marketSideValue) {
+  return makeLongShortContract(Ethers$FloatJsClient.wrapProvider(p)).marketSideValueInPaymentToken(marketIndex).then(function (marketSideValue) {
               if (isLong) {
                 return marketSideValue.long;
               } else {
@@ -75,23 +75,23 @@ function marketSideValue(p, marketIndex, isLong) {
 }
 
 function updateIndex(p, marketIndex, user) {
-  return makeLongShortContract(p).userNextPrice_currentUpdateIndex(marketIndex, user);
+  return makeLongShortContract(Ethers$FloatJsClient.wrapProvider(p)).userNextPrice_currentUpdateIndex(marketIndex, user);
 }
 
 function unsettledSynthBalance(p, marketIndex, isLong, user) {
-  return makeLongShortContract(p).getUsersConfirmedButNotSettledSynthBalance(user, marketIndex, isLong);
+  return makeLongShortContract(Ethers$FloatJsClient.wrapProvider(p)).getUsersConfirmedButNotSettledSynthBalance(user, marketIndex, isLong);
 }
 
 function marketSideUnconfirmedDeposits(p, marketIndex, isLong) {
-  return makeLongShortContract(p).batched_amountPaymentToken_deposit(marketIndex, isLong);
+  return makeLongShortContract(Ethers$FloatJsClient.wrapProvider(p)).batched_amountPaymentToken_deposit(marketIndex, isLong);
 }
 
 function marketSideUnconfirmedRedeems(p, marketIndex, isLong) {
-  return makeLongShortContract(p).batched_amountSyntheticToken_redeem(marketIndex, isLong);
+  return makeLongShortContract(Ethers$FloatJsClient.wrapProvider(p)).batched_amountSyntheticToken_redeem(marketIndex, isLong);
 }
 
 function marketSideUnconfirmedShifts(p, marketIndex, isShiftFromLong) {
-  return makeLongShortContract(p).batched_amountSyntheticToken_toShiftAwayFrom_marketSide(marketIndex, isShiftFromLong);
+  return makeLongShortContract(Ethers$FloatJsClient.wrapProvider(p)).batched_amountSyntheticToken_toShiftAwayFrom_marketSide(marketIndex, isShiftFromLong);
 }
 
 function syntheticTokenPrice(p, marketIndex, isLong) {
@@ -104,11 +104,11 @@ function syntheticTokenPrice(p, marketIndex, isLong) {
 }
 
 function syntheticTokenPriceSnapshot(p, marketIndex, isLong, priceSnapshotIndex) {
-  return makeLongShortContract(p).get_syntheticToken_priceSnapshot_side(marketIndex, isLong, priceSnapshotIndex);
+  return makeLongShortContract(Ethers$FloatJsClient.wrapProvider(p)).get_syntheticToken_priceSnapshot_side(marketIndex, isLong, priceSnapshotIndex);
 }
 
 function exposure(p, marketIndex, isLong) {
-  return makeLongShortContract(p).marketSideValueInPaymentToken(marketIndex).then(function (values) {
+  return marketSideValues(p, marketIndex).then(function (values) {
               var numerator = min(values.long, values.short).mul(CONSTANTS$FloatJsClient.tenToThe18);
               if (isLong) {
                 return numerator.div(values.long);
@@ -195,34 +195,34 @@ function unsettledPositions(p, marketIndex, isLong, address) {
 
 function mint(p, marketIndex, isLong, amountPaymentToken) {
   if (isLong) {
-    var partial_arg = makeLongShortContract(p);
+    var partial_arg = makeLongShortContract(Ethers$FloatJsClient.wrapWallet(p));
     return function (param) {
       return partial_arg.mintLongNextPrice(marketIndex, amountPaymentToken, param);
     };
   }
-  var partial_arg$1 = makeLongShortContract(p);
+  var partial_arg$1 = makeLongShortContract(Ethers$FloatJsClient.wrapWallet(p));
   return function (param) {
     return partial_arg$1.mintShortNextPrice(marketIndex, amountPaymentToken, param);
   };
 }
 
 function mintAndStake(p, marketIndex, isLong, amountPaymentToken) {
-  var partial_arg = makeLongShortContract(p);
+  var partial_arg = makeLongShortContract(Ethers$FloatJsClient.wrapWallet(p));
   return function (param) {
     return partial_arg.mintAndStakeNextPrice(marketIndex, amountPaymentToken, isLong, param);
   };
 }
 
 function stake(p, marketIndex, isLong, amountSyntheticToken, txOptions) {
-  return syntheticTokenAddress(p, marketIndex, isLong).then(function (address) {
-                return Promise.resolve(Contracts$FloatJsClient.Synth.make(address, p));
+  return syntheticTokenAddress(p.provider, marketIndex, isLong).then(function (address) {
+                return Promise.resolve(Contracts$FloatJsClient.Synth.make(address, Ethers$FloatJsClient.wrapWallet(p)));
               }).then(function (synth) {
               return synth.stake(amountSyntheticToken, txOptions);
             });
 }
 
 function unstake(p, marketIndex, isLong, amountSyntheticToken) {
-  var partial_arg = makeStakerContract(p);
+  var partial_arg = makeStakerContract(Ethers$FloatJsClient.wrapWallet(p));
   return function (param) {
     return partial_arg.withdraw(marketIndex, isLong, amountSyntheticToken, param);
   };
@@ -230,12 +230,12 @@ function unstake(p, marketIndex, isLong, amountSyntheticToken) {
 
 function redeem(p, marketIndex, isLong, amountSyntheticToken) {
   if (isLong) {
-    var partial_arg = makeLongShortContract(p);
+    var partial_arg = makeLongShortContract(Ethers$FloatJsClient.wrapWallet(p));
     return function (param) {
       return partial_arg.redeemLongNextPrice(marketIndex, amountSyntheticToken, param);
     };
   }
-  var partial_arg$1 = makeLongShortContract(p);
+  var partial_arg$1 = makeLongShortContract(Ethers$FloatJsClient.wrapWallet(p));
   return function (param) {
     return partial_arg$1.redeemShortNextPrice(marketIndex, amountSyntheticToken, param);
   };
@@ -243,25 +243,69 @@ function redeem(p, marketIndex, isLong, amountSyntheticToken) {
 
 function shift(p, marketIndex, isLong, amountSyntheticToken) {
   if (isLong) {
-    var partial_arg = makeLongShortContract(p);
+    var partial_arg = makeLongShortContract(Ethers$FloatJsClient.wrapWallet(p));
     return function (param) {
       return partial_arg.shiftPositionFromLongNextPrice(marketIndex, amountSyntheticToken, param);
     };
   }
-  var partial_arg$1 = makeLongShortContract(p);
+  var partial_arg$1 = makeLongShortContract(Ethers$FloatJsClient.wrapWallet(p));
   return function (param) {
-    return partial_arg$1.shiftPositionFromLongNextPrice(marketIndex, amountSyntheticToken, param);
+    return partial_arg$1.shiftPositionFromShortNextPrice(marketIndex, amountSyntheticToken, param);
   };
 }
 
 function shiftStake(p, marketIndex, isLong, amountSyntheticToken) {
-  var partial_arg = makeStakerContract(p);
+  var partial_arg = makeStakerContract(Ethers$FloatJsClient.wrapWallet(p));
   return function (param) {
     return partial_arg.shiftTokens(amountSyntheticToken, marketIndex, isLong, param);
   };
 }
 
-function newFloatMarketSide(p, marketIndex, isLong) {
+function makeWithWallet(w, marketIndex, isLong) {
+  return {
+          getSyntheticTokenPrice: (function (param) {
+              return syntheticTokenPrice(w.provider, marketIndex, isLong);
+            }),
+          getExposure: (function (param) {
+              return exposure(w.provider, marketIndex, isLong);
+            }),
+          getUnconfirmedExposure: (function (param) {
+              return unconfirmedExposure(w.provider, marketIndex, isLong);
+            }),
+          getPositions: (function (param) {
+              return positions(w.provider, marketIndex, isLong, Ethers.utils.getAddress(w._address));
+            }),
+          getStakedPositions: (function (param) {
+              return stakedPositions(w.provider, marketIndex, isLong, Ethers.utils.getAddress(w._address));
+            }),
+          getUnsettledPositions: (function (param) {
+              return unsettledPositions(w.provider, marketIndex, isLong, Ethers.utils.getAddress(w._address));
+            }),
+          mint: (function (param) {
+              return mint(w, marketIndex, isLong, param);
+            }),
+          mintAndStake: (function (param) {
+              return mintAndStake(w, marketIndex, isLong, param);
+            }),
+          stake: (function (param, param$1) {
+              return stake(w, marketIndex, isLong, param, param$1);
+            }),
+          unstake: (function (param) {
+              return unstake(w, marketIndex, isLong, param);
+            }),
+          redeem: (function (param) {
+              return redeem(w, marketIndex, isLong, param);
+            }),
+          shift: (function (param) {
+              return shift(w, marketIndex, isLong, param);
+            }),
+          shiftStake: (function (param) {
+              return shiftStake(w, marketIndex, isLong, param);
+            })
+        };
+}
+
+function makeWithProvider(p, marketIndex, isLong) {
   return {
           getSyntheticTokenPrice: (function (param) {
               return syntheticTokenPrice(p, marketIndex, isLong);
@@ -281,65 +325,44 @@ function newFloatMarketSide(p, marketIndex, isLong) {
           getUnsettledPositions: (function (param) {
               return unsettledPositions(p, marketIndex, isLong, param);
             }),
-          mint: (function (param) {
-              return mint(p, marketIndex, isLong, param);
-            }),
-          mintAndStake: (function (param) {
-              return mintAndStake(p, marketIndex, isLong, param);
-            }),
-          stake: (function (param, param$1) {
-              return stake(p, marketIndex, isLong, param, param$1);
-            }),
-          unstake: (function (param) {
-              return unstake(p, marketIndex, isLong, param);
-            }),
-          redeem: (function (param) {
-              return redeem(p, marketIndex, isLong, param);
-            }),
-          shift: (function (param) {
-              return shift(p, marketIndex, isLong, param);
-            }),
-          shiftStake: (function (param) {
-              return shiftStake(p, marketIndex, isLong, param);
+          connect: (function (w) {
+              return makeWithWallet(w, marketIndex, isLong);
             })
         };
 }
-
-var MarketSide = {
-  makeLongShortContract: makeLongShortContract,
-  makeStakerContract: makeStakerContract,
-  syntheticTokenAddress: syntheticTokenAddress,
-  syntheticTokenTotalSupply: syntheticTokenTotalSupply,
-  syntheticTokenBalance: syntheticTokenBalance,
-  stakedSyntheticTokenBalance: stakedSyntheticTokenBalance,
-  marketSideValues: marketSideValues,
-  marketSideValue: marketSideValue,
-  updateIndex: updateIndex,
-  unsettledSynthBalance: unsettledSynthBalance,
-  marketSideUnconfirmedDeposits: marketSideUnconfirmedDeposits,
-  marketSideUnconfirmedRedeems: marketSideUnconfirmedRedeems,
-  marketSideUnconfirmedShifts: marketSideUnconfirmedShifts,
-  syntheticTokenPrice: syntheticTokenPrice,
-  syntheticTokenPriceSnapshot: syntheticTokenPriceSnapshot,
-  exposure: exposure,
-  unconfirmedExposure: unconfirmedExposure,
-  positions: positions,
-  stakedPositions: stakedPositions,
-  unsettledPositions: unsettledPositions,
-  mint: mint,
-  mintAndStake: mintAndStake,
-  stake: stake,
-  unstake: unstake,
-  redeem: redeem,
-  shift: shift,
-  shiftStake: shiftStake,
-  newFloatMarketSide: newFloatMarketSide
-};
 
 exports.min = min;
 exports.div = div;
 exports.mul = mul;
 exports.add = add;
 exports.sub = sub;
-exports.MarketSide = MarketSide;
+exports.makeLongShortContract = makeLongShortContract;
+exports.makeStakerContract = makeStakerContract;
+exports.syntheticTokenAddress = syntheticTokenAddress;
+exports.syntheticTokenTotalSupply = syntheticTokenTotalSupply;
+exports.syntheticTokenBalance = syntheticTokenBalance;
+exports.stakedSyntheticTokenBalance = stakedSyntheticTokenBalance;
+exports.marketSideValues = marketSideValues;
+exports.marketSideValue = marketSideValue;
+exports.updateIndex = updateIndex;
+exports.unsettledSynthBalance = unsettledSynthBalance;
+exports.marketSideUnconfirmedDeposits = marketSideUnconfirmedDeposits;
+exports.marketSideUnconfirmedRedeems = marketSideUnconfirmedRedeems;
+exports.marketSideUnconfirmedShifts = marketSideUnconfirmedShifts;
+exports.syntheticTokenPrice = syntheticTokenPrice;
+exports.syntheticTokenPriceSnapshot = syntheticTokenPriceSnapshot;
+exports.exposure = exposure;
+exports.unconfirmedExposure = unconfirmedExposure;
+exports.positions = positions;
+exports.stakedPositions = stakedPositions;
+exports.unsettledPositions = unsettledPositions;
+exports.mint = mint;
+exports.mintAndStake = mintAndStake;
+exports.stake = stake;
+exports.unstake = unstake;
+exports.redeem = redeem;
+exports.shift = shift;
+exports.shiftStake = shiftStake;
+exports.makeWithWallet = makeWithWallet;
+exports.makeWithProvider = makeWithProvider;
 /* ethers Not a pure module */

--- a/src/MarketSide.res
+++ b/src/MarketSide.res
@@ -5,357 +5,392 @@ open Promise
 
 let {min, div, mul, add, sub} = module(Ethers.BigNumber)
 
-// TODO wallet: provider VS providerOrSigner
-// We should differentiate, 'cause some actions need a signer and some just a provider
-module MarketSide = {
-  type b = {
-    paymentToken: BigNumber.t,
-    synthToken: BigNumber.t,
+type b = {
+  paymentToken: BigNumber.t,
+  synthToken: BigNumber.t,
+}
+
+type marketSideWithWallet = {
+  getSyntheticTokenPrice: unit => Promise.t<Ethers.BigNumber.t>,
+  getExposure: unit => Promise.t<Ethers.BigNumber.t>,
+  getUnconfirmedExposure: unit => Promise.t<Ethers.BigNumber.t>,
+  getPositions: unit => Promise.t<b>,
+  getStakedPositions: unit => Promise.t<b>,
+  getUnsettledPositions: unit => Promise.t<b>,
+  mint: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
+  mintAndStake: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
+  stake: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
+  unstake: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
+  redeem: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
+  shift: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
+  shiftStake: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
+}
+
+type marketSideWithProvider = {
+  getSyntheticTokenPrice: unit => Promise.t<Ethers.BigNumber.t>,
+  getExposure: unit => Promise.t<Ethers.BigNumber.t>,
+  getUnconfirmedExposure: unit => Promise.t<Ethers.BigNumber.t>,
+  getPositions: ethAddress => Promise.t<b>,
+  getStakedPositions: ethAddress => Promise.t<b>,
+  getUnsettledPositions: ethAddress => Promise.t<b>,
+  connect: walletType => marketSideWithWallet,
+}
+
+let makeLongShortContract = (p: providerOrWallet) =>
+  LongShort.make(
+    ~address=polygonConfig.longShortContractAddress->Utils.getAddressUnsafe,
+    ~providerOrWallet=p,
+  )
+
+// TODO was getting weird type error here
+//let makeSynth = (p: providerOrWallet, address: ethAddress) =>
+//    Synth.make(~address, ~providerOrWallet=p)
+
+let makeStakerContract = (p: providerOrWallet) =>
+  Staker.make(
+    ~address=polygonConfig.stakerContractAddress->Utils.getAddressUnsafe,
+    ~providerOrWallet=p,
+  )
+
+let syntheticTokenAddress = (p: providerType, marketIndex: BigNumber.t, isLong: bool) =>
+  p->wrapProvider->makeLongShortContract->LongShort.syntheticTokens(~marketIndex, ~isLong)
+
+let syntheticTokenTotalSupply = (p: providerType, marketIndex: BigNumber.t, isLong: bool) =>
+  p
+  ->syntheticTokenAddress(marketIndex, isLong)
+  ->then(address => resolve(address->Synth.make(~providerOrWallet=p->wrapProvider)))
+  ->then(synth => synth->Synth.totalSupply)
+
+let syntheticTokenBalance = (
+  p: providerType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  owner: ethAddress,
+) =>
+  p
+  ->syntheticTokenAddress(marketIndex, isLong)
+  ->then(address => resolve(address->Synth.make(~providerOrWallet=p->wrapProvider)))
+  ->then(synth => synth->Synth.balanceOf(~owner))
+
+let stakedSyntheticTokenBalance = (
+  p: providerType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  owner: ethAddress,
+) =>
+  p
+  ->syntheticTokenAddress(marketIndex, isLong)
+  ->then(token => p->wrapProvider->makeStakerContract->Staker.userAmountStaked(~token, ~owner))
+
+let marketSideValues = (p: providerType, marketIndex: BigNumber.t): Promise.t<
+  LongShort.marketSideValue,
+> => p->wrapProvider->makeLongShortContract->LongShort.marketSideValueInPaymentToken(~marketIndex)
+
+let marketSideValue = (p: providerType, marketIndex: BigNumber.t, isLong: bool) =>
+  p
+  ->wrapProvider
+  ->makeLongShortContract
+  ->LongShort.marketSideValueInPaymentToken(~marketIndex)
+  ->thenResolve(marketSideValue =>
+    switch isLong {
+    | true => marketSideValue.long
+    | false => marketSideValue.short
+    }
+  )
+
+let updateIndex = (p: providerType, marketIndex: BigNumber.t, user: ethAddress) =>
+  p
+  ->wrapProvider
+  ->makeLongShortContract
+  ->LongShort.userNextPrice_currentUpdateIndex(~marketIndex, ~user)
+
+let unsettledSynthBalance = (
+  p: providerType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  user: ethAddress,
+) =>
+  p
+  ->wrapProvider
+  ->makeLongShortContract
+  ->LongShort.getUsersConfirmedButNotSettledSynthBalance(~marketIndex, ~isLong, ~user)
+
+let marketSideUnconfirmedDeposits = (p: providerType, marketIndex: BigNumber.t, isLong: bool) =>
+  p
+  ->wrapProvider
+  ->makeLongShortContract
+  ->LongShort.batched_amountPaymentToken_deposit(~marketIndex, ~isLong)
+
+let marketSideUnconfirmedRedeems = (p: providerType, marketIndex: BigNumber.t, isLong: bool) =>
+  p
+  ->wrapProvider
+  ->makeLongShortContract
+  ->LongShort.batched_amountSyntheticToken_redeem(~marketIndex, ~isLong)
+
+let marketSideUnconfirmedShifts = (
+  p: providerType,
+  marketIndex: BigNumber.t,
+  isShiftFromLong: bool,
+) =>
+  p
+  ->wrapProvider
+  ->makeLongShortContract
+  ->LongShort.batched_amountSyntheticToken_toShiftAwayFrom_marketSide(
+    ~marketIndex,
+    ~isLong=isShiftFromLong,
+  )
+
+let syntheticTokenPrice = (p: providerType, marketIndex: BigNumber.t, isLong: bool) =>
+  all2((
+    marketSideValue(p, marketIndex, isLong),
+    syntheticTokenTotalSupply(p, marketIndex, isLong),
+  ))->thenResolve(((value, total)) =>
+    value->BigNumber.mul(CONSTANTS.tenToThe18)->BigNumber.div(total)
+  )
+
+let syntheticTokenPriceSnapshot = (
+  p: providerType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  priceSnapshotIndex: BigNumber.t,
+) =>
+  p
+  ->wrapProvider
+  ->makeLongShortContract
+  ->LongShort.get_syntheticToken_priceSnapshot_side(~marketIndex, ~isLong, ~priceSnapshotIndex)
+
+let exposure = (p: providerType, marketIndex: BigNumber.t, isLong: bool) =>
+  marketSideValues(p, marketIndex)->thenResolve(values => {
+    let numerator = values.long->min(values.short)->mul(CONSTANTS.tenToThe18)
+    switch isLong {
+    | true => numerator->div(values.long)
+    | false => numerator->div(values.short)
+    }
+  })
+
+let unconfirmedExposure = (p: providerType, marketIndex: BigNumber.t, isLong: bool) =>
+  all([
+    syntheticTokenPrice(p, marketIndex, true),
+    syntheticTokenPrice(p, marketIndex, false),
+    marketSideUnconfirmedRedeems(p, marketIndex, true),
+    marketSideUnconfirmedRedeems(p, marketIndex, false),
+    marketSideUnconfirmedShifts(p, marketIndex, true),
+    marketSideUnconfirmedShifts(p, marketIndex, false),
+    marketSideUnconfirmedDeposits(p, marketIndex, true),
+    marketSideUnconfirmedDeposits(p, marketIndex, false),
+    marketSideValue(p, marketIndex, true),
+    marketSideValue(p, marketIndex, false),
+  ])->thenResolve(results => {
+    let priceLong = results[0]
+    let priceShort = results[1]
+    let redeemsLong = results[2]
+    let redeemsShort = results[3]
+    let shiftsFromLong = results[4]
+    let shiftsFromShort = results[5]
+    let depositsLong = results[6]
+    let depositsShort = results[7]
+    let valueLong = results[8]
+    let valueShort = results[9]
+
+    let unconfirmedValueLong =
+      shiftsFromShort
+      ->sub(shiftsFromLong)
+      ->sub(redeemsLong)
+      ->mul(priceLong)
+      ->div(CONSTANTS.tenToThe18)
+      ->add(depositsLong)
+      ->add(valueLong)
+
+    let unconfirmedValueShort =
+      shiftsFromLong
+      ->sub(shiftsFromShort)
+      ->sub(redeemsShort)
+      ->mul(priceShort)
+      ->div(CONSTANTS.tenToThe18)
+      ->add(depositsShort)
+      ->add(valueShort)
+
+    let numerator = unconfirmedValueLong->min(unconfirmedValueShort)->mul(CONSTANTS.tenToThe18)
+
+    switch isLong {
+    | true => numerator->div(unconfirmedValueLong)
+    | false => numerator->div(unconfirmedValueShort)
+    }
+  })
+
+let positions = (p: providerType, marketIndex: BigNumber.t, isLong: bool, address: ethAddress) =>
+  all2((
+    syntheticTokenBalance(p, marketIndex, isLong, address),
+    syntheticTokenPrice(p, marketIndex, isLong),
+  ))->thenResolve(((balance, price)) => {
+    paymentToken: balance->mul(price),
+    synthToken: balance,
+  })
+
+let stakedPositions = (
+  p: providerType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  address: ethAddress,
+) =>
+  all2((
+    stakedSyntheticTokenBalance(p, marketIndex, isLong, address),
+    syntheticTokenPrice(p, marketIndex, isLong),
+  ))->thenResolve(((balance, price)) => {
+    paymentToken: balance->mul(price),
+    synthToken: balance,
+  })
+
+// TODO add users unconfirmed positions
+
+let unsettledPositions = (
+  p: providerType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  address: ethAddress,
+) =>
+  updateIndex(p, marketIndex, address)
+  ->then(index =>
+    all2((
+      syntheticTokenPriceSnapshot(p, marketIndex, isLong, index),
+      unsettledSynthBalance(p, marketIndex, isLong, address),
+    ))
+  )
+  ->thenResolve(((price, balance)) => {
+    paymentToken: balance->mul(price),
+    synthToken: balance,
+  })
+
+let mint = (
+  p: walletType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  amountPaymentToken: BigNumber.t,
+) =>
+  switch isLong {
+  | true =>
+    p
+    ->wrapWallet
+    ->makeLongShortContract
+    ->LongShort.mintLongNextPrice(~marketIndex, ~amountPaymentToken)
+  | false =>
+    p
+    ->wrapWallet
+    ->makeLongShortContract
+    ->LongShort.mintShortNextPrice(~marketIndex, ~amountPaymentToken)
   }
 
-  type a = {
-    getSyntheticTokenPrice: unit => Promise.t<Ethers.BigNumber.t>,
-    getExposure: unit => Promise.t<Ethers.BigNumber.t>,
-    getUnconfirmedExposure: unit => Promise.t<Ethers.BigNumber.t>,
-    getPositions: ethAddress => Promise.t<b>,
-    getStakedPositions: ethAddress => Promise.t<b>,
-    getUnsettledPositions: ethAddress => Promise.t<b>,
-    mint: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
-    mintAndStake: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
-    stake: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
-    unstake: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
-    redeem: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
-    shift: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
-    shiftStake: (BigNumber.t, txOptions) => Promise.t<Ethers.txSubmitted>,
+let mintAndStake = (
+  p: walletType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  amountPaymentToken: BigNumber.t,
+) =>
+  p
+  ->wrapWallet
+  ->makeLongShortContract
+  ->LongShort.mintAndStakeNextPrice(~marketIndex, ~amountPaymentToken, ~isLong)
+
+let stake = (
+  p: walletType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  amountSyntheticToken: BigNumber.t,
+  txOptions: txOptions,
+) =>
+  p.provider
+  ->syntheticTokenAddress(marketIndex, isLong)
+  ->then(address => resolve(address->Synth.make(~providerOrWallet=p->wrapWallet)))
+  ->then(synth => synth->Synth.stake(~amountSyntheticToken, txOptions))
+
+let unstake = (
+  p: walletType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  amountSyntheticToken: BigNumber.t,
+) =>
+  p
+  ->wrapWallet
+  ->makeStakerContract
+  ->Staker.withdraw(~marketIndex, ~isWithdrawFromLong=isLong, ~amountSyntheticToken)
+
+let redeem = (
+  p: walletType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  amountSyntheticToken: BigNumber.t,
+) =>
+  switch isLong {
+  | true =>
+    p
+    ->wrapWallet
+    ->makeLongShortContract
+    ->LongShort.redeemLongNextPrice(~marketIndex, ~amountSyntheticToken)
+  | false =>
+    p
+    ->wrapWallet
+    ->makeLongShortContract
+    ->LongShort.redeemShortNextPrice(~marketIndex, ~amountSyntheticToken)
   }
 
-  let makeLongShortContract = (p: providerOrSigner) =>
-    LongShort.make(
-      ~address=polygonConfig.longShortContractAddress->Utils.getAddressUnsafe,
-      ~providerOrSigner=p,
-    )
-
-  // TODO was getting weird type error here
-  //let makeSynth = (p: providerOrSigner, address: ethAddress) =>
-  //    Synth.make(~address, ~providerOrSigner=p)
-
-  let makeStakerContract = (p: providerOrSigner) =>
-    Staker.make(
-      ~address=polygonConfig.stakerContractAddress->Utils.getAddressUnsafe,
-      ~providerOrSigner=p,
-    )
-
-  let syntheticTokenAddress = (p: providerOrSigner, marketIndex: BigNumber.t, isLong: bool) =>
-    p->makeLongShortContract->LongShort.syntheticTokens(~marketIndex, ~isLong)
-
-  let syntheticTokenTotalSupply = (p: providerOrSigner, marketIndex: BigNumber.t, isLong: bool) =>
+let shift = (
+  p: walletType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  amountSyntheticToken: BigNumber.t,
+) =>
+  switch isLong {
+  | true =>
     p
-    ->syntheticTokenAddress(marketIndex, isLong)
-    ->then(address => resolve(address->Synth.make(~providerOrSigner=p)))
-    ->then(synth => synth->Synth.totalSupply)
-
-  let syntheticTokenBalance = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    owner: ethAddress,
-  ) =>
-    p
-    ->syntheticTokenAddress(marketIndex, isLong)
-    ->then(address => resolve(address->Synth.make(~providerOrSigner=p)))
-    ->then(synth => synth->Synth.balanceOf(~owner))
-
-  let stakedSyntheticTokenBalance = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    owner: ethAddress,
-  ) =>
-    p
-    ->syntheticTokenAddress(marketIndex, isLong)
-    ->then(token => p->makeStakerContract->Staker.userAmountStaked(~token, ~owner))
-
-  let marketSideValues = (p: providerOrSigner, marketIndex: BigNumber.t): Promise.t<
-    LongShort.marketSideValue,
-  > => p->makeLongShortContract->LongShort.marketSideValueInPaymentToken(~marketIndex)
-
-  let marketSideValue = (p: providerOrSigner, marketIndex: BigNumber.t, isLong: bool) =>
-    p
+    ->wrapWallet
     ->makeLongShortContract
-    ->LongShort.marketSideValueInPaymentToken(~marketIndex)
-    ->thenResolve(marketSideValue =>
-      switch isLong {
-      | true => marketSideValue.long
-      | false => marketSideValue.short
-      }
-    )
-
-  let updateIndex = (p: providerOrSigner, marketIndex: BigNumber.t, user: ethAddress) =>
-    p->makeLongShortContract->LongShort.userNextPrice_currentUpdateIndex(~marketIndex, ~user)
-
-  let unsettledSynthBalance = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    user: ethAddress,
-  ) =>
+    ->LongShort.shiftPositionFromLongNextPrice(~marketIndex, ~amountSyntheticToken)
+  | false =>
     p
+    ->wrapWallet
     ->makeLongShortContract
-    ->LongShort.getUsersConfirmedButNotSettledSynthBalance(~marketIndex, ~isLong, ~user)
+    ->LongShort.shiftPositionFromShortNextPrice(~marketIndex, ~amountSyntheticToken)
+  }
 
-  let marketSideUnconfirmedDeposits = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-  ) => makeLongShortContract(p)->LongShort.batched_amountPaymentToken_deposit(~marketIndex, ~isLong)
+let shiftStake = (
+  p: walletType,
+  marketIndex: BigNumber.t,
+  isLong: bool,
+  amountSyntheticToken: BigNumber.t,
+) =>
+  p
+  ->wrapWallet
+  ->makeStakerContract
+  ->Staker.shiftTokens(~amountSyntheticToken, ~marketIndex, ~isShiftFromLong=isLong)
 
-  let marketSideUnconfirmedRedeems = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-  ) =>
-    makeLongShortContract(p)->LongShort.batched_amountSyntheticToken_redeem(~marketIndex, ~isLong)
+// TODO we should not be using getAddressUnsafe
+//   rather we should do error handling properly
+let makeWithWallet = (w: walletType, marketIndex: BigNumber.t, isLong: bool) => {
+  {
+    getSyntheticTokenPrice: _ => syntheticTokenPrice(w.provider, marketIndex, isLong),
+    getExposure: _ => exposure(w.provider, marketIndex, isLong),
+    getUnconfirmedExposure: _ => unconfirmedExposure(w.provider, marketIndex, isLong),
+    getPositions: _ => positions(w.provider, marketIndex, isLong, w.address->Utils.getAddressUnsafe),
+    getStakedPositions: _ => stakedPositions(w.provider, marketIndex, isLong, w.address->Utils.getAddressUnsafe),
+    getUnsettledPositions: _ => unsettledPositions(w.provider, marketIndex, isLong, w.address->Utils.getAddressUnsafe),
+    mint: mint(w, marketIndex, isLong),
+    mintAndStake: mintAndStake(w, marketIndex, isLong),
+    stake: stake(w, marketIndex, isLong),
+    unstake: unstake(w, marketIndex, isLong),
+    redeem: redeem(w, marketIndex, isLong),
+    shift: shift(w, marketIndex, isLong),
+    shiftStake: shiftStake(w, marketIndex, isLong),
+  }
+}
 
-  let marketSideUnconfirmedShifts = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isShiftFromLong: bool,
-  ) =>
-    makeLongShortContract(p)->LongShort.batched_amountSyntheticToken_toShiftAwayFrom_marketSide(
-      ~marketIndex,
-      ~isLong=isShiftFromLong,
-    )
-
-  let syntheticTokenPrice = (p: providerOrSigner, marketIndex: BigNumber.t, isLong: bool) =>
-    all2((
-      marketSideValue(p, marketIndex, isLong),
-      syntheticTokenTotalSupply(p, marketIndex, isLong),
-    ))->thenResolve(((value, total)) =>
-      value->BigNumber.mul(CONSTANTS.tenToThe18)->BigNumber.div(total)
-    )
-
-  let syntheticTokenPriceSnapshot = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    priceSnapshotIndex: BigNumber.t,
-  ) =>
-    p
-    ->makeLongShortContract
-    ->LongShort.get_syntheticToken_priceSnapshot_side(~marketIndex, ~isLong, ~priceSnapshotIndex)
-
-  let exposure = (p: providerOrSigner, marketIndex: BigNumber.t, isLong: bool) =>
-    marketSideValues(p, marketIndex)->thenResolve(values => {
-      let numerator = values.long->min(values.short)->mul(CONSTANTS.tenToThe18)
-      switch isLong {
-      | true => numerator->div(values.long)
-      | false => numerator->div(values.short)
-      }
-    })
-
-  let unconfirmedExposure = (p: providerOrSigner, marketIndex: BigNumber.t, isLong: bool) =>
-    all([
-      syntheticTokenPrice(p, marketIndex, true),
-      syntheticTokenPrice(p, marketIndex, false),
-      marketSideUnconfirmedRedeems(p, marketIndex, true),
-      marketSideUnconfirmedRedeems(p, marketIndex, false),
-      marketSideUnconfirmedShifts(p, marketIndex, true),
-      marketSideUnconfirmedShifts(p, marketIndex, false),
-      marketSideUnconfirmedDeposits(p, marketIndex, true),
-      marketSideUnconfirmedDeposits(p, marketIndex, false),
-      marketSideValue(p, marketIndex, true),
-      marketSideValue(p, marketIndex, false),
-    ])->thenResolve(results => {
-      let priceLong = results[0]
-      let priceShort = results[1]
-      let redeemsLong = results[2]
-      let redeemsShort = results[3]
-      let shiftsFromLong = results[4]
-      let shiftsFromShort = results[5]
-      let depositsLong = results[6]
-      let depositsShort = results[7]
-      let valueLong = results[8]
-      let valueShort = results[9]
-
-      let unconfirmedValueLong =
-        shiftsFromShort
-        ->sub(shiftsFromLong)
-        ->sub(redeemsLong)
-        ->mul(priceLong)
-        ->div(CONSTANTS.tenToThe18)
-        ->add(depositsLong)
-        ->add(valueLong)
-
-      let unconfirmedValueShort =
-        shiftsFromLong
-        ->sub(shiftsFromShort)
-        ->sub(redeemsShort)
-        ->mul(priceShort)
-        ->div(CONSTANTS.tenToThe18)
-        ->add(depositsShort)
-        ->add(valueShort)
-
-      let numerator = unconfirmedValueLong->min(unconfirmedValueShort)->mul(CONSTANTS.tenToThe18)
-
-      switch isLong {
-      | true => numerator->div(unconfirmedValueLong)
-      | false => numerator->div(unconfirmedValueShort)
-      }
-    })
-
-  // TODO allow address to be inferred from providerOrSigner
-  let positions = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    address: ethAddress,
-  ) =>
-    //~includeStake=false,
-    //~includeNextPrice=false) =>
-    all2((
-      syntheticTokenBalance(p, marketIndex, isLong, address),
-      syntheticTokenPrice(p, marketIndex, isLong),
-    ))->thenResolve(((balance, price)) => {
-      paymentToken: balance->mul(price),
-      synthToken: balance,
-    })
-
-  // TODO allow address to be inferred from providerOrSigner
-  let stakedPositions = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    address: ethAddress,
-  ) =>
-    all2((
-      stakedSyntheticTokenBalance(p, marketIndex, isLong, address),
-      syntheticTokenPrice(p, marketIndex, isLong),
-    ))->thenResolve(((balance, price)) => {
-      paymentToken: balance->mul(price),
-      synthToken: balance,
-    })
-
-  // TODO add users unconfirmed positions
-
-  // TODO allow address to be inferred from providerOrSigner
-  let unsettledPositions = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    address: ethAddress,
-  ) =>
-    updateIndex(p, marketIndex, address)
-    ->then(index =>
-      all2((
-        syntheticTokenPriceSnapshot(p, marketIndex, isLong, index),
-        unsettledSynthBalance(p, marketIndex, isLong, address),
-      ))
-    )
-    ->thenResolve(((price, balance)) => {
-      paymentToken: balance->mul(price),
-      synthToken: balance,
-    })
-
-  let mint = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    amountPaymentToken: BigNumber.t,
-  ) =>
-    switch isLong {
-    | true =>
-      p->makeLongShortContract->LongShort.mintLongNextPrice(~marketIndex, ~amountPaymentToken)
-    | false =>
-      p->makeLongShortContract->LongShort.mintShortNextPrice(~marketIndex, ~amountPaymentToken)
-    }
-
-  let mintAndStake = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    amountPaymentToken: BigNumber.t,
-  ) =>
-    p
-    ->makeLongShortContract
-    ->LongShort.mintAndStakeNextPrice(~marketIndex, ~amountPaymentToken, ~isLong)
-
-  let stake = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    amountSyntheticToken: BigNumber.t,
-    txOptions: txOptions,
-  ) =>
-    p
-    ->syntheticTokenAddress(marketIndex, isLong)
-    ->then(address => resolve(address->Synth.make(~providerOrSigner=p)))
-    ->then(synth => synth->Synth.stake(~amountSyntheticToken, txOptions))
-
-  let unstake = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    amountSyntheticToken: BigNumber.t,
-  ) =>
-      p
-      ->makeStakerContract
-      ->Staker.withdraw(~marketIndex, ~isWithdrawFromLong=isLong, ~amountSyntheticToken)
-
-  let redeem = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    amountSyntheticToken: BigNumber.t,
-  ) =>
-    switch isLong {
-    | true =>
-      p->makeLongShortContract->LongShort.redeemLongNextPrice(~marketIndex, ~amountSyntheticToken)
-    | false =>
-      p->makeLongShortContract->LongShort.redeemShortNextPrice(~marketIndex, ~amountSyntheticToken)
-    }
-
-  let shift = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    amountSyntheticToken: BigNumber.t,
-  ) =>
-    switch isLong {
-    | true =>
-      p
-      ->makeLongShortContract
-      ->LongShort.shiftPositionFromLongNextPrice(~marketIndex, ~amountSyntheticToken)
-    | false =>
-      p
-      ->makeLongShortContract
-      ->LongShort.shiftPositionFromLongNextPrice(~marketIndex, ~amountSyntheticToken)
-    }
-
-  let shiftStake = (
-    p: providerOrSigner,
-    marketIndex: BigNumber.t,
-    isLong: bool,
-    amountSyntheticToken: BigNumber.t,
-  ) =>
-    p
-    ->makeStakerContract
-    ->Staker.shiftTokens(~amountSyntheticToken, ~marketIndex, ~isShiftFromLong=isLong)
-
-  let newFloatMarketSide = (p: providerOrSigner, marketIndex: BigNumber.t, isLong: bool) => {
-    {
-      getSyntheticTokenPrice: _ => syntheticTokenPrice(p, marketIndex, isLong),
-      getExposure: _ => exposure(p, marketIndex, isLong),
-      getUnconfirmedExposure: _ => unconfirmedExposure(p, marketIndex, isLong),
-      getPositions: positions(p, marketIndex, isLong),
-      getStakedPositions: stakedPositions(p, marketIndex, isLong),
-      getUnsettledPositions: unsettledPositions(p, marketIndex, isLong),
-      mint: mint(p, marketIndex, isLong),
-      mintAndStake: mintAndStake(p, marketIndex, isLong),
-      stake: stake(p, marketIndex, isLong),
-      unstake: unstake(p, marketIndex, isLong),
-      redeem: redeem(p, marketIndex, isLong),
-      shift: shift(p, marketIndex, isLong),
-      shiftStake: shiftStake(p, marketIndex, isLong),
-    }
+let makeWithProvider = (p: providerType, marketIndex: BigNumber.t, isLong: bool) => {
+  {
+    getSyntheticTokenPrice: _ => syntheticTokenPrice(p, marketIndex, isLong),
+    getExposure: _ => exposure(p, marketIndex, isLong),
+    getUnconfirmedExposure: _ => unconfirmedExposure(p, marketIndex, isLong),
+    getPositions: positions(p, marketIndex, isLong),
+    getStakedPositions: stakedPositions(p, marketIndex, isLong),
+    getUnsettledPositions: unsettledPositions(p, marketIndex, isLong),
+    connect: w => makeWithWallet(w, marketIndex, isLong),
   }
 }

--- a/src/demo.js
+++ b/src/demo.js
@@ -4,7 +4,6 @@
 var Curry = require("rescript/lib/js/curry.js");
 var Ethers = require("ethers");
 var SecretsManagerJs = require("../secretsManager.js");
-var Ethers$FloatJsClient = require("./demo/Ethers.js");
 var CONSTANTS$FloatJsClient = require("./demo/CONSTANTS.js");
 var MarketSide$FloatJsClient = require("./MarketSide.js");
 
@@ -19,10 +18,10 @@ function connectToNewWallet(provider, mnemonic) {
 }
 
 function run(param) {
-  var $$float = MarketSide$FloatJsClient.MarketSide.newFloatMarketSide(Ethers$FloatJsClient.getSigner(connectToNewWallet(new (Ethers.providers.JsonRpcProvider)(providerUrl, 137), mnemonic)), Ethers.BigNumber.from(1), true);
+  var marketSide = MarketSide$FloatJsClient.makeWithProvider(new (Ethers.providers.JsonRpcProvider)(providerUrl, 137), Ethers.BigNumber.from(1), false);
   var maxFeePerGas = Ethers.BigNumber.from(62).mul(CONSTANTS$FloatJsClient.oneGweiInWei);
   var maxPriorityFeePerGas = Ethers.BigNumber.from(34).mul(CONSTANTS$FloatJsClient.oneGweiInWei);
-  var gasLimit = Ethers.BigNumber.from(600000);
+  var gasLimit = Ethers.BigNumber.from(1000000);
   var txOptions_maxFeePerGas = maxFeePerGas.toString();
   var txOptions_maxPriorityFeePerGas = maxPriorityFeePerGas.toString();
   var txOptions_gasLimit = gasLimit.toString();
@@ -31,7 +30,20 @@ function run(param) {
     maxPriorityFeePerGas: txOptions_maxPriorityFeePerGas,
     gasLimit: txOptions_gasLimit
   };
-  return Curry._2($$float.shiftStake, Ethers.BigNumber.from(22).mul(CONSTANTS$FloatJsClient.tenToThe18).div(CONSTANTS$FloatJsClient.tenToThe2), txOptions).then(function (tx) {
+  Curry._1(marketSide.getUnconfirmedExposure, undefined).then(function (a) {
+        console.log(a.toString());
+        
+      });
+  Curry._1(marketSide.getExposure, undefined).then(function (a) {
+        console.log(a.toString());
+        
+      });
+  Curry._1(marketSide.getPositions, Ethers.utils.getAddress("0x380d3d688fd65ef6858f0e094a1a9bba03ad76a3")).then(function (a) {
+        console.log(a.synthToken.toString());
+        
+      });
+  var marketSideConnected = Curry._1(marketSide.connect, connectToNewWallet(new (Ethers.providers.JsonRpcProvider)(providerUrl, 137), mnemonic));
+  return Curry._2(marketSideConnected.shift, Ethers.BigNumber.from(1).mul(CONSTANTS$FloatJsClient.tenToThe18), txOptions).then(function (tx) {
               console.log(tx.hash);
               
             });

--- a/src/demo.res
+++ b/src/demo.res
@@ -35,16 +35,21 @@ let connectToNewWallet = (provider, ~mnemonic) =>
   Wallet.fromMnemonicWithPath(~mnemonic, ~path=`m/44'/60'/0'/0/0`)->Wallet.connect(provider)
 
 let run = () => {
-  let float =
+  //let marketSideConnected =
+  //  providerUrl
+  //  ->Provider.JsonRpcProvider.make(~chainId=137)
+  //  ->connectToNewWallet(~mnemonic)
+  //  ->MarketSide.makeWithWallet(BigNumber.fromInt(1), false)
+
+  let marketSide =
     providerUrl
-    ->Providers.JsonRpcProvider.make(~chainId=137)
-    ->connectToNewWallet(~mnemonic)
-    ->getSigner
-    ->MarketSide.MarketSide.newFloatMarketSide(BigNumber.fromInt(1), true)
+    ->Provider.JsonRpcProvider.make(~chainId=137)
+    //->connectToNewWallet(~mnemonic)
+    ->MarketSide.makeWithProvider(BigNumber.fromInt(1), false)
 
   let maxFeePerGas = BigNumber.fromInt(62)->BigNumber.mul(CONSTANTS.oneGweiInWei)
   let maxPriorityFeePerGas = BigNumber.fromInt(34)->BigNumber.mul(CONSTANTS.oneGweiInWei)
-  let gasLimit = BigNumber.fromInt(600000)
+  let gasLimit = BigNumber.fromInt(1000000)
 
   let txOptions: Contracts.txOptions = {
     maxFeePerGas: maxFeePerGas->BigNumber.toString,
@@ -52,17 +57,24 @@ let run = () => {
     gasLimit: gasLimit->BigNumber.toString,
   }
 
-  //float.getUnconfirmedExposure()->Promise.thenResolve(a => a->BigNumber.toString->Js.log)->ignore
-  //float.getExposure()->Promise.thenResolve(a => a->BigNumber.toString->Js.log)->ignore
-  //float.getStakedPositions("0x5b7a3a14D0488eaC9c1A1f943A80ECD983711797"->Utils.getAddressUnsafe)
-  //->Promise.thenResolve(a => a.paymentToken->BigNumber.toString->Js.log)
+  marketSide.getUnconfirmedExposure()->Promise.thenResolve(a => a->BigNumber.toString->Js.log)->ignore
+  marketSide.getExposure()->Promise.thenResolve(a => a->BigNumber.toString->Js.log)->ignore
+  marketSide.getPositions("0x380d3d688fd65ef6858f0e094a1a9bba03ad76a3"->Utils.getAddressUnsafe)
+  ->Promise.thenResolve(a => a.synthToken->BigNumber.toString->Js.log)->ignore
 
-  // TODO is just the shift that is not working
-  float.shift(BigNumber.fromInt(22)->BigNumber.mul(CONSTANTS.tenToThe18)->BigNumber.div(CONSTANTS.tenToThe2), txOptions)
-  ->Promise.thenResolve(tx => tx.hash->Js.log)
+  let marketSideConnected =
+    providerUrl
+    ->Provider.JsonRpcProvider.make(~chainId=137)
+    ->connectToNewWallet(~mnemonic)
+    ->marketSide.connect
+
+  marketSideConnected.shift(
+    BigNumber.fromInt(1)->BigNumber.mul(CONSTANTS.tenToThe18),//->BigNumber.div(CONSTANTS.tenToThe2),
+    txOptions,
+  )->Promise.thenResolve(tx => tx.hash->Js.log)
 
   //providerUrl
-  //->Providers.JsonRpcProvider.make(~chainId)
+  //->Provider.JsonRpcProvider.make(~chainId)
   //->connectToNewWallet(~mnemonic)
   //->Wallet.getBalance
   //->Promise.thenResolve(balance => {

--- a/src/demo/Contracts.js
+++ b/src/demo/Contracts.js
@@ -24,8 +24,8 @@ var abi = Ethers$FloatJsClient.makeAbi([
       "function getUsersConfirmedButNotSettledSynthBalance(address user, uint32 marketIndex, bool isLong) view returns (uint256 amount)"
     ]);
 
-function make(address, providerOrSigner) {
-  return Ethers$FloatJsClient.Contract.make(address, abi, providerOrSigner);
+function make(address, providerOrWallet) {
+  return Ethers$FloatJsClient.Contract.make(address, abi, providerOrWallet);
 }
 
 var LongShort = {
@@ -41,8 +41,8 @@ var abi$1 = Ethers$FloatJsClient.makeAbi([
       "function userAmountStaked(address, address) public view returns (uint256)"
     ]);
 
-function make$1(address, providerOrSigner) {
-  return Ethers$FloatJsClient.Contract.make(address, abi$1, providerOrSigner);
+function make$1(address, providerOrWallet) {
+  return Ethers$FloatJsClient.Contract.make(address, abi$1, providerOrWallet);
 }
 
 var Staker = {
@@ -57,8 +57,8 @@ var abi$2 = Ethers$FloatJsClient.makeAbi([
       "function mint(uint256 value) public returns (bool)"
     ]);
 
-function make$2(address, providerOrSigner) {
-  return Ethers$FloatJsClient.Contract.make(address, abi$2, providerOrSigner);
+function make$2(address, providerOrWallet) {
+  return Ethers$FloatJsClient.Contract.make(address, abi$2, providerOrWallet);
 }
 
 var Erc20 = {
@@ -74,8 +74,8 @@ var abi$3 = Ethers$FloatJsClient.makeAbi([
       "function totalSupply() external view returns (uint256 total)"
     ]);
 
-function make$3(address, providerOrSigner) {
-  return Ethers$FloatJsClient.Contract.make(address, abi$3, providerOrSigner);
+function make$3(address, providerOrWallet) {
+  return Ethers$FloatJsClient.Contract.make(address, abi$3, providerOrWallet);
 }
 
 var Synth = {
@@ -85,8 +85,8 @@ var Synth = {
 
 var abi$4 = Ethers$FloatJsClient.makeAbi(["function mintNFT(uint256 levelId, address receiver) external"]);
 
-function make$4(address, providerOrSigner) {
-  return Ethers$FloatJsClient.Contract.make(address, abi$4, providerOrSigner);
+function make$4(address, providerOrWallet) {
+  return Ethers$FloatJsClient.Contract.make(address, abi$4, providerOrWallet);
 }
 
 var GemCollectorNFT = {

--- a/src/demo/Contracts.res
+++ b/src/demo/Contracts.res
@@ -36,8 +36,8 @@ module LongShort = {
       "function getUsersConfirmedButNotSettledSynthBalance(address user, uint32 marketIndex, bool isLong) view returns (uint256 amount)",
     ]->Ethers.makeAbi
 
-  let make = (~address, ~providerOrSigner): t =>
-    Ethers.Contract.make(address, abi, providerOrSigner)
+  let make = (~address, ~providerOrWallet): t =>
+    Ethers.Contract.make(address, abi, providerOrWallet)
 
   @send
   external mintLongNextPrice: (
@@ -175,8 +175,8 @@ module Staker = {
       "function userAmountStaked(address, address) public view returns (uint256)",
     ]->Ethers.makeAbi
 
-  let make = (~address, ~providerOrSigner): t =>
-    Ethers.Contract.make(address, abi, providerOrSigner)
+  let make = (~address, ~providerOrWallet): t =>
+    Ethers.Contract.make(address, abi, providerOrWallet)
 
   @send
   external withdraw: (
@@ -235,8 +235,8 @@ module Erc20 = {
       "function mint(uint256 value) public returns (bool)",
     ]->Ethers.makeAbi
 
-  let make = (~address, ~providerOrSigner): t =>
-    Ethers.Contract.make(address, abi, providerOrSigner)
+  let make = (~address, ~providerOrWallet): t =>
+    Ethers.Contract.make(address, abi, providerOrWallet)
 
   @send
   external approve: (
@@ -277,7 +277,7 @@ module Synth = {
       "function totalSupply() external view returns (uint256 total)",
     ]->Ethers.makeAbi
 
-  let make = (address, ~providerOrSigner): t => Ethers.Contract.make(address, abi, providerOrSigner)
+  let make = (address, ~providerOrWallet): t => Ethers.Contract.make(address, abi, providerOrWallet)
 
   @send
   external approve: (
@@ -313,8 +313,8 @@ module GemCollectorNFT = {
 
   let abi = ["function mintNFT(uint256 levelId, address receiver) external"]->Ethers.makeAbi
 
-  let make = (~address, ~providerOrSigner): t =>
-    Ethers.Contract.make(address, abi, providerOrSigner)
+  let make = (~address, ~providerOrWallet): t =>
+    Ethers.Contract.make(address, abi, providerOrWallet)
 
   @send
   external mintNFT: (

--- a/src/demo/Ethers.js
+++ b/src/demo/Ethers.js
@@ -55,16 +55,23 @@ var JsonRpcProvider = {};
 
 var FallbackProvider = {};
 
-var Providers = {
+var Provider = {
   JsonRpcProvider: JsonRpcProvider,
   FallbackProvider: FallbackProvider
 };
 
 var Wallet = {};
 
-function getSigner(w) {
+function wrapProvider(p) {
   return {
-          TAG: /* Signer */1,
+          TAG: /* ProviderWrap */0,
+          _0: p
+        };
+}
+
+function wrapWallet(w) {
+  return {
+          TAG: /* WalletWrap */1,
           _0: w
         };
 }
@@ -154,9 +161,10 @@ var Utils = {
 exports.Misc = Misc;
 exports.makeAbi = makeAbi;
 exports.BigNumber = BigNumber;
-exports.Providers = Providers;
+exports.Provider = Provider;
 exports.Wallet = Wallet;
-exports.getSigner = getSigner;
+exports.wrapProvider = wrapProvider;
+exports.wrapWallet = wrapWallet;
 exports.Contract = Contract;
 exports.Utils = Utils;
 /* tenBN Not a pure module */


### PR DESCRIPTION
Closes: #26 

The providerOrSigner type becomes a bit clumsy in some circumstances so this
change favours either provider OR wallet, and leaves the providerOrSigner type
only to the contract calls.

Also, the term 'signer' is not used in Ethers.js so it can be confusing to use
since actually it is synonymous with 'wallet', so that term has been removed
completely.

The marketSide code has been adjusted so that, when implemented, either the
provider-connected version or the wallet-connected version needs to be chosen.
This helps narrow the definitions of the contract calls since some can be made
with just a provider while others need the more strict wallet connection.